### PR TITLE
Add terraform fmt pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -10,3 +10,9 @@
   entry: dos2unix
   language: python
   files: .*
+- id: terraform_fmt
+  name: terraform fmt
+  description: Format Terraform files using terraform fmt
+  entry: terraform_fmt
+  language: python
+  files: \.tf$

--- a/pre_commit_hooks/terraform_fmt.py
+++ b/pre_commit_hooks/terraform_fmt.py
@@ -1,0 +1,27 @@
+import argparse
+import subprocess
+from typing import Sequence
+
+
+def run_terraform_fmt(filenames: list[str]) -> int:
+    """Run terraform fmt on the given files."""
+    for filename in filenames:
+        result = subprocess.run(['terraform', 'fmt', filename])
+        if result.returncode != 0:
+            return result.returncode
+    return 0
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        'filenames', nargs='*',
+        help='Filenames pre-commit believes are changed.',
+    )
+    args = parser.parse_args(argv)
+
+    return run_terraform_fmt(args.filenames)
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,4 @@ install_requires =
 console_scripts =
     check-binary-files = pre_commit_hooks.check_binary_files:main
     dos2unix = pre_commit_hooks.dos2unix:main
+    terraform_fmt = pre_commit_hooks.terraform_fmt:main


### PR DESCRIPTION
Fixes #1

Add a pre-commit hook to run `terraform fmt`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/deamen/pre-commit-hooks/pull/2?shareId=c16177e1-8afc-4cd7-8817-53576da757d0).